### PR TITLE
Require initializer path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,14 @@ npm install asset-fingerprint-webpack-rails --save-dev
 ## Usage
 **Note:** _You will likely want to avoid running the fingerprinting in anything but a production build. Otherwise, if you have file watching setup for instance, it will rebuild the fingerprinting each time a file is updated, requiring you to bounce the Rails server to pickup the new fingerprint. One way to avoid this is by passing an option to your command for dev vs prod: (`webpack` for dev without fingerprinting, and `webpack --env.fingerprint` for prod build)._
 
-This plugin assumes you have a `config/initializers` directory in your project. It uses the `hash` values from the webpack `stats` object. This is the value that will be output into a new initializer called `asset_fingerprint.rb`, as: `ASSET_FINGERPRINT=XXXXXXXX`. You should setup your `webpack.config.js` to use this hash when building your output file (see sample config below).
+This plugin requires you to set your initializer directory path relative to your webpack config, such as: `config/initializers` as the first argument. The second optional argument determines whether or not the fingerprinting should take place. By default, this is set to `true`.
+
+```javascript
+const AssetFingerprintPlugin = require('asset-fingerprint-webpack-rails');
+new AssetFingerprintPlugin('config/initializers', true);
+```
+
+It uses the `hash` values from the webpack `stats` object. This is the value that will be output into a new initializer called `asset_fingerprint.rb`, as: `ASSET_FINGERPRINT=XXXXXXXX`. You should setup your `webpack.config.js` to use this hash when building your output file (see sample config below).
 
 It is also recommended that you use a plugin such as [clean-webpack-plugin](https://github.com/johnagan/clean-webpack-plugin) in conjunction with this plugin to clean out your output directory on each build, if you wish to avoid a collection of old files.
 
@@ -26,7 +33,7 @@ Use a local variable in `webpack.config.js` to pass into the plugin to inform it
  */
 const AssetFingerprintPlugin = require('asset-fingerprint-webpack-rails');
 const needsFingerprint = someLocalBoolean;
-
+const initializerDirectory = 'config/initializers';
 /**
  * add it to your plugins and conditionally use the hash in the filename
  */
@@ -37,7 +44,7 @@ module.exports = {
     filename: needsFingerprint ? "bundle-[hash].js" : "bundle.js"
   },
   plugins: [
-    new AssetFingerprintPlugin(needsFingerprint)
+    new AssetFingerprintPlugin(initializerDirectory, needsFingerprint)
   ]
 };
 ```
@@ -69,7 +76,7 @@ module.exports = function(fingerprint) {
         filename: "bundle-[hash].js"
       },
       plugins: [
-        new AssetFingerprintPlugin()
+        new AssetFingerprintPlugin(initializerDirectory)
       ]
     }
   } else {
@@ -85,7 +92,7 @@ module.exports = function(fingerprint) {
 ```
 
 ### Integration with Rails
-Now that our `config/initializers/asset_fingerprint.rb` file is setup, we can conditionally use it in our views by setting up a helper method in `application_helper.rb`:
+Now that our `asset_fingerprint.rb` file is setup, we can conditionally use it in our views by setting up a helper method in `application_helper.rb`:
 
 ```ruby
   def asset_with_fingerprint(asset_name)

--- a/index.js
+++ b/index.js
@@ -1,14 +1,25 @@
 const fs = require('fs');
 
-function AssetFingerprint(needsFingerprint = true) {
+function AssetFingerprint(initializerDirectory, needsFingerprint = true) {
+  _validateInitializerDirectory();
+
+  this.initializerDirectory = initializerDirectory;
   this.needsFingerprint = needsFingerprint;
+
+  function _validateInitializerDirectory() {
+    if (initializerDirectory === undefined) {
+      throw new Error('Please supply a directory path for your initializer, such as `config/initializers`.');
+    }
+  }
 }
 
 AssetFingerprint.prototype.apply = function(compiler) {
   compiler.plugin('done', function(stats) {
     if (this.needsFingerprint) {
       let output = `ASSET_FINGERPRINT = '${stats.hash}'`;
-      fs.writeFileSync('config/initializers/asset_fingerprint.rb', output)
+      let initializerPath = `${this.initializerDirectory}/asset_fingerprint.rb`;
+
+      fs.writeFileSync(initializerPath, output);
     }
   }.bind(this));
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset-fingerprint-webpack-rails",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A webpack plugin to fingerprint your JS for consumption by Rails",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset-fingerprint-webpack-rails",
-  "version": "0.1.2",
+  "version": "1.1.1",
   "description": "A webpack plugin to fingerprint your JS for consumption by Rails",
   "main": "index.js",
   "scripts": {

--- a/spec/indexSpec.js
+++ b/spec/indexSpec.js
@@ -3,24 +3,39 @@ describe("AssetFingerprint", function() {
   var fingerprint;
 
   describe("initialization", function() {
-    it("should default needsFingerprint = true when no args", function() {
-      fingerprint = new AssetFingerprint();
-      expect(fingerprint.needsFingerprint).toBeTruthy();
+      describe("needsFingerprint", function() {
+      it("should default needsFingerprint = true when no args", function() {
+        fingerprint = new AssetFingerprint('');
+        expect(fingerprint.needsFingerprint).toBeTruthy();
+      });
+
+      it("should accept true", function() {
+        fingerprint = new AssetFingerprint('', true);
+        expect(fingerprint.needsFingerprint).toBeTruthy();
+      });
+
+      it("should accept false", function() {
+        fingerprint = new AssetFingerprint('', false);
+        expect(fingerprint.needsFingerprint).toBeFalsy();
+      });
+
+      it("should accept null", function() {
+        fingerprint = new AssetFingerprint('', null);
+        expect(fingerprint.needsFingerprint).toBeFalsy();
+      });
     });
 
-    it("should accept true", function() {
-      fingerprint = new AssetFingerprint(true);
-      expect(fingerprint.needsFingerprint).toBeTruthy();
-    });
+    describe("initializer path", function() {
+      it("should set when supplied", function() {
+        var dir = 'config/initializers';
+        fingerprint = new AssetFingerprint(dir, true);
+        expect(fingerprint.initializerDirectory).toEqual(dir);
+      });
 
-    it("should accept false", function() {
-      fingerprint = new AssetFingerprint(false);
-      expect(fingerprint.needsFingerprint).toBeFalsy();
-    });
-
-    it("should accept null", function() {
-      fingerprint = new AssetFingerprint(null);
-      expect(fingerprint.needsFingerprint).toBeFalsy();
+      it("should fail when not supplied", function() {
+        fingerprint = function() { new AssetFingerprint(); }
+        expect(fingerprint).toThrowError('Please supply a directory path for your initializer, such as `config/initializers`.');
+      });
     });
   });
 });


### PR DESCRIPTION
This updates the signature of `AssetFingerprint` to require an initializer directory path as the first argument, which will allow users to set a path relative to their webpack config.